### PR TITLE
Refactor global gradient backgrounds across sections

### DIFF
--- a/src/app/components/sections/cta-section/cta-section.component.css
+++ b/src/app/components/sections/cta-section/cta-section.component.css
@@ -1,5 +1,5 @@
 #cta {
-  background: linear-gradient(135deg, var(--athenity-blue-deep) 0%, rgba(10, 25, 47, 0.95) 100%);
+  background: transparent;
 }
 
 /* Enhanced CTA animations */

--- a/src/app/components/sections/servicos-section/servicos-section.component.css
+++ b/src/app/components/sections/servicos-section/servicos-section.component.css
@@ -1,5 +1,5 @@
 #servicos {
-  background: linear-gradient(135deg, var(--athenity-blue-deep) 0%, rgba(17, 34, 64, 0.95) 100%);
+  background: transparent;
   overflow: hidden; /* Prevent parallax overflow */
 }
 

--- a/src/app/components/three-particle-background/three-particle-background.component.ts
+++ b/src/app/components/three-particle-background/three-particle-background.component.ts
@@ -21,7 +21,7 @@ interface Shockwave {
       left: 0;
       width: 100%;
       height: 100%;
-      z-index: -1;
+      z-index: -2;
       outline: none;
     }
   `]

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,20 +65,30 @@
   }
 
   body {
-    @apply bg-athenity-blue-deep text-athenity-text-body font-sans;
+    @apply text-athenity-text-body font-sans;
     margin: 0;
     padding: 0;
     line-height: 1.6;
     overflow-x: hidden;
     height: 100%;
-    
+
+    background:
+      radial-gradient(140% 100% at 0% 0%, rgba(100, 255, 218, 0.12) 0%, transparent 55%),
+      radial-gradient(120% 120% at 80% 10%, rgba(255, 215, 0, 0.08) 0%, transparent 65%),
+      radial-gradient(120% 120% at 50% 120%, rgba(64, 224, 208, 0.08) 0%, transparent 70%),
+      linear-gradient(160deg, #050b16 0%, #0a192f 42%, #08152a 68%, #050e1f 100%);
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+    background-size: cover;
+    color: var(--athenity-text-body);
+
     /* Support for safe area insets on mobile */
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
-    
+
     /* Improve touch scrolling on iOS */
     -webkit-overflow-scrolling: touch;
-    
+
     /* Prevent text selection on touch devices for UI elements */
     -webkit-touch-callout: none;
   }
@@ -248,15 +258,50 @@
     @apply w-full flex items-center;
     padding-left: var(--spacing-lg);
     padding-right: var(--spacing-lg);
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
-    
+    padding-top: calc(var(--spacing-section) + env(safe-area-inset-top));
+    padding-bottom: calc(var(--spacing-section) + env(safe-area-inset-bottom));
+
     /* Use CSS custom property for dynamic viewport height */
     min-height: calc(var(--vh, 1vh) * 100);
     min-height: 100vh; /* Fallback */
     min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
-    
+
     position: relative;
+    isolation: isolate;
+    overflow: hidden;
+  }
+
+  .section-base::before {
+    content: '';
+    position: absolute;
+    inset: clamp(2.5rem, 8vw, 5rem) clamp(1.5rem, 6vw, 4rem);
+    background: linear-gradient(180deg, rgba(11, 23, 43, 0.92) 0%, rgba(7, 15, 29, 0.86) 50%, rgba(6, 12, 24, 0.9) 100%);
+    border-radius: clamp(1.75rem, 5vw, 3.5rem);
+    border: 1px solid rgba(100, 255, 218, 0.08);
+    box-shadow: 0 45px 90px rgba(3, 8, 20, 0.7);
+    pointer-events: none;
+    z-index: -1;
+    transition: opacity var(--duration-slow) ease, transform var(--duration-slow) ease;
+  }
+
+  @supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
+    .section-base::before {
+      background: linear-gradient(180deg, rgba(11, 23, 43, 0.72) 0%, rgba(7, 15, 29, 0.68) 55%, rgba(6, 12, 24, 0.76) 100%);
+      -webkit-backdrop-filter: blur(28px);
+      backdrop-filter: blur(28px);
+    }
+  }
+
+  .section-base:not(:first-of-type)::after {
+    content: '';
+    position: absolute;
+    top: clamp(1.25rem, 4vw, 3rem);
+    left: clamp(2rem, 10vw, 12rem);
+    right: clamp(2rem, 10vw, 12rem);
+    height: 1px;
+    background: linear-gradient(90deg, transparent 0%, rgba(100, 255, 218, 0.25) 50%, transparent 100%);
+    opacity: 0.45;
+    pointer-events: none;
   }
 
   .section-content {
@@ -270,9 +315,21 @@
     .section-base {
       padding-left: var(--spacing-md);
       padding-right: var(--spacing-md);
+      padding-top: calc(var(--spacing-section) * 0.75 + env(safe-area-inset-top));
+      padding-bottom: calc(var(--spacing-section) * 0.75 + env(safe-area-inset-bottom));
       min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     }
-    
+
+    .section-base::before {
+      inset: clamp(1.5rem, 12vw, 3rem) clamp(1rem, 8vw, 2.5rem);
+      border-radius: clamp(1.25rem, 8vw, 2.5rem);
+    }
+
+    .section-base:not(:first-of-type)::after {
+      left: clamp(1.5rem, 14vw, 5rem);
+      right: clamp(1.5rem, 14vw, 5rem);
+    }
+
     .section-content {
       padding-left: 0;
       padding-right: 0;
@@ -283,6 +340,13 @@
     .section-base {
       padding-left: var(--spacing-sm);
       padding-right: var(--spacing-sm);
+      padding-top: calc(var(--spacing-section) * 0.6 + env(safe-area-inset-top));
+      padding-bottom: calc(var(--spacing-section) * 0.6 + env(safe-area-inset-bottom));
+    }
+
+    .section-base::before {
+      inset: clamp(1.25rem, 14vw, 2.25rem) clamp(0.75rem, 10vw, 1.75rem);
+      border-radius: clamp(1rem, 10vw, 2rem);
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the body background with a layered gradient that spans the entire experience
- add reusable glassy overlays to section containers to visually separate each block
- remove individual section gradients and adjust the particle background z-index to sit under the new overlay

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc42e094008333ada6cd20fa5f37c6