### PR TITLE
style: unify page gradient backgrounds

### DIFF
--- a/src/app/components/sections/cta-section/cta-section.component.css
+++ b/src/app/components/sections/cta-section/cta-section.component.css
@@ -1,5 +1,8 @@
 #cta {
-  background: linear-gradient(135deg, var(--athenity-blue-deep) 0%, rgba(10, 25, 47, 0.95) 100%);
+  --section-surface-bg: linear-gradient(150deg, rgba(13, 28, 54, 0.88) 0%, rgba(7, 18, 36, 0.74) 100%);
+  --section-surface-border: rgba(255, 215, 0, 0.2);
+  --section-surface-shadow: 0 35px 80px rgba(5, 12, 26, 0.5);
+  --section-divider-opacity: 0.32;
 }
 
 /* Enhanced CTA animations */

--- a/src/app/components/sections/cta-section/cta-section.component.html
+++ b/src/app/components/sections/cta-section/cta-section.component.html
@@ -1,7 +1,8 @@
-<section 
+<section
   #sectionElement
-  id="cta" 
+  id="cta"
   class="section-base"
+  [ngClass]="getSectionClasses()"
   [attr.data-testid]="testId">
   
   <div class="section-content text-center px-4 sm:px-6 lg:px-8">
@@ -21,7 +22,8 @@
     </p>
 
     <!-- CTA Buttons Container -->
-    <div class="cta-buttons mt-8 sm:mt-10 flex flex-col sm:flex-row gap-4 justify-center items-stretch sm:items-center max-w-lg mx-auto"
+    <div class="cta-buttons mt-8 sm:mt-10 flex gap-4 justify-center items-stretch sm:items-center max-w-lg mx-auto"
+         [ngClass]="getButtonLayoutClasses()"
          [attr.data-testid]="'cta-buttons'">
       
       <!-- Primary CTA Button -->

--- a/src/app/components/sections/cta-section/cta-section.component.ts
+++ b/src/app/components/sections/cta-section/cta-section.component.ts
@@ -208,27 +208,20 @@ export class CtaSectionComponent implements AfterViewInit, OnDestroy {
    * Get section classes based on configuration
    */
   getSectionClasses(): string {
-    const classes: string[] = [];
-    
     switch (this.backgroundColor) {
       case 'deep':
-        classes.push('bg-athenity-blue-deep');
-        break;
+        return 'surface-deep';
       case 'gradient':
-        classes.push('bg-gradient-to-b from-athenity-blue-deep to-athenity-blue-card');
-        break;
+        return 'surface-highlight';
       default:
-        // Use default styling from template
-        break;
+        return 'surface-minimal';
     }
+  }
 
-    if (this.buttonLayout === 'stacked') {
-      classes.push('flex-col');
-    } else {
-      classes.push('flex-row');
-    }
-    
-    return classes.join(' ');
+  getButtonLayoutClasses(): string {
+    return this.buttonLayout === 'stacked'
+      ? 'flex-col sm:flex-col'
+      : 'flex-col sm:flex-row';
   }
 
   /**

--- a/src/app/components/sections/filosofia-section/filosofia-section.component.css
+++ b/src/app/components/sections/filosofia-section/filosofia-section.component.css
@@ -1,3 +1,11 @@
+.section-base#filosofia {
+  --section-surface-inset: clamp(1.25rem, 3.5vw, 3.5rem);
+  --section-surface-bg: linear-gradient(150deg, rgba(16, 32, 58, 0.9) 0%, rgba(9, 20, 38, 0.72) 100%);
+  --section-surface-border: rgba(100, 255, 218, 0.1);
+  --section-surface-shadow: 0 40px 90px rgba(4, 10, 24, 0.55);
+  --section-divider-opacity: 0.36;
+}
+
 .filosofia-content {
   opacity: 0;
   transform: translateX(-30px);

--- a/src/app/components/sections/hero-section/hero-section.component.css
+++ b/src/app/components/sections/hero-section/hero-section.component.css
@@ -1,3 +1,11 @@
+section#hero {
+  --section-surface-inset: clamp(1rem, 3vw, 3rem);
+  --section-surface-bg: linear-gradient(180deg, rgba(12, 26, 48, 0.82) 0%, rgba(6, 14, 28, 0.58) 100%);
+  --section-surface-border: rgba(100, 255, 218, 0.18);
+  --section-surface-shadow: 0 40px 85px rgba(4, 12, 28, 0.55);
+  --section-divider-opacity: 0.24;
+}
+
 /* Hero section elements with GPU acceleration */
 #hero-title,
 #hero-subtitle,

--- a/src/app/components/sections/servicos-section/servicos-section.component.css
+++ b/src/app/components/sections/servicos-section/servicos-section.component.css
@@ -1,6 +1,9 @@
 #servicos {
-  background: linear-gradient(135deg, var(--athenity-blue-deep) 0%, rgba(17, 34, 64, 0.95) 100%);
   overflow: hidden; /* Prevent parallax overflow */
+  --section-surface-bg: linear-gradient(165deg, rgba(18, 36, 66, 0.92) 0%, rgba(11, 24, 45, 0.78) 100%);
+  --section-surface-border: rgba(100, 255, 218, 0.14);
+  --section-surface-shadow: 0 40px 90px rgba(5, 15, 32, 0.55);
+  --section-divider-opacity: 0.42;
 }
 
 .servicos-grid {

--- a/src/app/components/sections/servicos-section/servicos-section.component.ts
+++ b/src/app/components/sections/servicos-section/servicos-section.component.ts
@@ -121,13 +121,13 @@ export class ServicosSectionComponent implements AfterViewInit, OnDestroy {
 
     switch (this.backgroundColor) {
       case 'deep':
-        classes.push('bg-athenity-blue-deep');
+        classes.push('surface-deep');
         break;
       case 'gradient':
-        classes.push('bg-gradient-to-b from-athenity-blue-deep to-athenity-blue-card');
+        classes.push('surface-highlight');
         break;
       default:
-        // Use default styling from template
+        classes.push('surface-minimal');
         break;
     }
 

--- a/src/app/components/sections/trabalhos-section/trabalhos-section.component.css
+++ b/src/app/components/sections/trabalhos-section/trabalhos-section.component.css
@@ -2,6 +2,11 @@
   position: relative;
   height: 100vh;
   overflow-x: hidden;
+  --section-surface-inset: clamp(1rem, 3.5vw, 3rem);
+  --section-surface-bg: linear-gradient(170deg, rgba(15, 30, 56, 0.9) 0%, rgba(9, 20, 40, 0.72) 100%);
+  --section-surface-border: rgba(100, 255, 218, 0.12);
+  --section-surface-shadow: 0 45px 95px rgba(5, 12, 30, 0.6);
+  --section-divider-opacity: 0.4;
 }
 
 .section-content {

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,12 +65,22 @@
   }
 
   body {
-    @apply bg-athenity-blue-deep text-athenity-text-body font-sans;
+    @apply text-athenity-text-body font-sans;
     margin: 0;
     padding: 0;
     line-height: 1.6;
     overflow-x: hidden;
     height: 100%;
+
+    background-color: #050914;
+    background-image:
+      radial-gradient(at 20% 20%, rgba(100, 255, 218, 0.18), transparent 55%),
+      radial-gradient(at 80% 0%, rgba(255, 215, 0, 0.12), transparent 60%),
+      radial-gradient(at 80% 85%, rgba(64, 224, 208, 0.08), transparent 55%),
+      linear-gradient(180deg, #050914 0%, #071327 38%, #0a192f 72%, #0b1f3d 100%);
+    background-attachment: fixed;
+    background-size: cover;
+    color: var(--athenity-text-body);
     
     /* Support for safe area insets on mobile */
     padding-left: env(safe-area-inset-left);
@@ -250,13 +260,78 @@
     padding-right: var(--spacing-lg);
     padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
-    
+
     /* Use CSS custom property for dynamic viewport height */
     min-height: calc(var(--vh, 1vh) * 100);
     min-height: 100vh; /* Fallback */
     min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
-    
+
     position: relative;
+    isolation: isolate;
+    z-index: 0;
+
+    --section-surface-inset: clamp(1.5rem, 4vw, 4rem);
+    --section-surface-radius: clamp(1.5rem, 5vw, 3rem);
+    --section-surface-bg: linear-gradient(160deg, rgba(17, 34, 64, 0.88) 0%, rgba(10, 21, 42, 0.78) 100%);
+    --section-surface-border: rgba(100, 255, 218, 0.08);
+    --section-surface-shadow: 0 45px 90px rgba(5, 12, 26, 0.55);
+    --section-divider-opacity: 0.35;
+  }
+
+  .section-base::before {
+    content: '';
+    position: absolute;
+    inset: var(--section-surface-inset);
+    border-radius: var(--section-surface-radius);
+    background: var(--section-surface-bg);
+    border: 1px solid var(--section-surface-border);
+    box-shadow: var(--section-surface-shadow);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    opacity: 0.98;
+    pointer-events: none;
+    z-index: -2;
+    transition: background var(--duration-slow) ease, border-color var(--duration-slow) ease,
+      box-shadow var(--duration-slow) ease, opacity var(--duration-slow) ease;
+  }
+
+  .section-base::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(var(--section-surface-inset) * 0.6);
+    width: min(80vw, 60rem);
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(100, 255, 218, var(--section-divider-opacity)), transparent);
+    opacity: 0.55;
+    filter: blur(0.5px);
+    pointer-events: none;
+    z-index: -3;
+    transition: opacity var(--duration-slow) ease;
+  }
+
+  .section-base:last-of-type::after,
+  .section-base[data-divider="false"]::after {
+    opacity: 0;
+  }
+
+  .section-base.surface-minimal {
+    --section-surface-bg: linear-gradient(150deg, rgba(13, 28, 54, 0.78) 0%, rgba(8, 18, 36, 0.62) 100%);
+    --section-surface-border: rgba(100, 255, 218, 0.08);
+    --section-divider-opacity: 0.24;
+  }
+
+  .section-base.surface-deep {
+    --section-surface-bg: linear-gradient(165deg, rgba(18, 36, 66, 0.92) 0%, rgba(11, 24, 45, 0.78) 100%);
+    --section-surface-border: rgba(100, 255, 218, 0.16);
+    --section-divider-opacity: 0.4;
+  }
+
+  .section-base.surface-highlight {
+    --section-surface-bg: linear-gradient(155deg, rgba(16, 34, 62, 0.86) 0%, rgba(9, 20, 38, 0.7) 100%);
+    --section-surface-border: rgba(255, 215, 0, 0.22);
+    --section-divider-opacity: 0.34;
   }
 
   .section-content {
@@ -271,8 +346,12 @@
       padding-left: var(--spacing-md);
       padding-right: var(--spacing-md);
       min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+
+      --section-surface-inset: clamp(0.75rem, 4vw, 2.25rem);
+      --section-surface-radius: clamp(1.25rem, 6vw, 2.25rem);
+      --section-divider-opacity: 0.25;
     }
-    
+
     .section-content {
       padding-left: 0;
       padding-right: 0;
@@ -283,6 +362,10 @@
     .section-base {
       padding-left: var(--spacing-sm);
       padding-right: var(--spacing-sm);
+
+      --section-surface-inset: clamp(0.5rem, 5vw, 1.5rem);
+      --section-surface-radius: clamp(1rem, 7vw, 1.75rem);
+      --section-divider-opacity: 0.18;
     }
   }
 


### PR DESCRIPTION
## Summary
- apply a single multi-layer gradient to the body background and add reusable surface styling for section containers
- tune each landing page section to use the shared surface variables instead of bespoke gradients and keep CTA layout controls working

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc42e094008333ada6cd20fa5f37c6