### PR TITLE
Amplify drag release momentum and reliable snapping

### DIFF
--- a/src/app/components/work-card-ring/work-card-ring.component.css
+++ b/src/app/components/work-card-ring/work-card-ring.component.css
@@ -14,7 +14,7 @@
   height: clamp(280px, 80vmin, 420px);
   position: relative;
   overflow: visible;
-  touch-action: none;
+  touch-action: pan-y;
 }
 
 .ring {

--- a/src/app/services/animation/trabalhos-section-animation.service.ts
+++ b/src/app/services/animation/trabalhos-section-animation.service.ts
@@ -152,6 +152,45 @@ export class TrabalhosSectionAnimationService {
     if (!ringElement) return;
     this.ringEl = ringElement;
     ringElement.style.cursor = 'grab';
+
+    if (typeof workCardRingComponent.registerInteractionBridge === 'function') {
+      workCardRingComponent.registerInteractionBridge({
+        onDragStart: () => {
+          this.isDragging = true;
+          workCardRingComponent.isDragging = true;
+          ringElement.style.cursor = 'grabbing';
+          ringElement.classList.add('ring-dragging');
+          if (navigator.vibrate) navigator.vibrate(30);
+        },
+        onDragMove: (rotation: number, velocity: number) => {
+          this.dragVelocity = velocity;
+          if (this.currentRingComponent && 'rotationDeg' in this.currentRingComponent) {
+            this.currentRingComponent.rotationDeg = rotation;
+          }
+          ringElement.classList.remove('snap-transition');
+          ringElement.style.setProperty('--rotation', `${-rotation}deg`);
+        },
+        onDragEnd: (velocity: number) => {
+          this.isDragging = false;
+          workCardRingComponent.isDragging = false;
+          this.dragVelocity = velocity;
+          ringElement.style.cursor = 'grab';
+          ringElement.classList.remove('ring-dragging');
+          if (navigator.vibrate) navigator.vibrate(20);
+        },
+        onActiveIndexChange: (index: number) => {
+          this.highlightActiveCard(index);
+          if (navigator.vibrate) navigator.vibrate([50, 50, 50]);
+        }
+      });
+
+      this.disposers.push(() => {
+        workCardRingComponent.registerInteractionBridge(null);
+      });
+
+      return;
+    }
+
     const onPointerDown = (ev: PointerEvent) => {
       this.isDragging = true;
       workCardRingComponent.isDragging = true;


### PR DESCRIPTION
## Summary
- boost the release inertia by scaling drag exit velocity while respecting reasonable caps
- track pending snaps and apply delayed, forceful snapping so manual drags always settle on a card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd997fbacc83338fbc658c26ccf61f