### PR TITLE
Fix servicos section nested scroll

### DIFF
--- a/src/app/components/sections/servicos-section/servicos-section.component.css
+++ b/src/app/components/sections/servicos-section/servicos-section.component.css
@@ -1,6 +1,22 @@
+:host {
+  display: block;
+}
+
 #servicos {
   background: linear-gradient(135deg, var(--athenity-blue-deep) 0%, rgba(17, 34, 64, 0.95) 100%);
   overflow: hidden; /* Prevent parallax overflow */
+}
+
+.section-content {
+  max-height: none;
+  overflow: visible;
+}
+
+@media (max-width: 896px) and (orientation: landscape) {
+  .section-content {
+    max-height: none;
+    overflow: visible;
+  }
 }
 
 .servicos-grid {


### PR DESCRIPTION
## Summary
- ensure the Serviços section container is block-level and remove the inherited max-height and overflow limits to avoid inner scrollbars
- keep the landscape mobile breakpoint from forcing overflow scrolling inside the Serviços content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68deb561fef4833394d4c4d847c54082