### PR TITLE
Fix double scroll on Serviços section in landscape view

### DIFF
--- a/src/app/components/sections/servicos-section/servicos-section.component.css
+++ b/src/app/components/sections/servicos-section/servicos-section.component.css
@@ -3,6 +3,14 @@
   overflow: hidden; /* Prevent parallax overflow */
 }
 
+@media (max-width: 896px) and (orientation: landscape) {
+  #servicos .section-content {
+    /* Allow the services grid to expand naturally on small landscape viewports */
+    max-height: none;
+    overflow: visible;
+  }
+}
+
 .servicos-grid {
   opacity: 1;
   transform: none;


### PR DESCRIPTION
## Summary
- override the global landscape overflow rule for the serviços section so its content can expand naturally
- prevent the services grid from creating an inner scrollbar on small landscape viewports

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68deb561fef4833394d4c4d847c54082